### PR TITLE
Instead of assuming first line is "sat", find it

### DIFF
--- a/validate-model.py
+++ b/validate-model.py
@@ -9,16 +9,21 @@ smt_file = chc_file[:-4] + "-validate.smt2"
 
 funs = {}
 
+
 def define_funs(cmds, funs):
     for cmd in cmds:
         match cmd:
             case ("define-fun", name, *args):
                 funs[name] = cmd
 
+
 if True:
     file = sys.stdin
-    status = file.readline().strip()
-    assert status == "sat"
+    for line in file:
+        if line.strip() == "sat":
+            break
+    else:
+        raise ValueError("No line with 'sat' found")
     content = file.read()
     model = smtlib.parse_exprs(content)
 
@@ -34,8 +39,8 @@ if True:
             define_funs(cmds, funs)
 
 with open(chc_file, "r") as file:
-   content = file.read()
-   cmds = smtlib.parse_exprs(content)
+    content = file.read()
+    cmds = smtlib.parse_exprs(content)
 
 defs = []
 clauses = []
@@ -54,11 +59,11 @@ for cmd in cmds:
         case ("assert", phi):
             clauses.append(phi)
 
-        case ("check-sat", ):
+        case ("check-sat",):
             pass
-        case ("get-model", ):
+        case ("get-model",):
             pass
-        case ("exit", ):
+        case ("exit",):
             pass
 
         case _:


### PR DESCRIPTION
Some tools output some warnings, etc, before outputting the result (potentially to stderr, but if stdout and stderr are merged, as with BenchExec, then we cannot detect this). 

Therefore, instead of asserting/assuming the first line will be `sat`, first find it, and assume the model comes immediately after.

Also, I ran `black` to format the file. Let me know if I should revert it.